### PR TITLE
Use native environment variables component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,4 +47,4 @@ task wrapper(type: Wrapper) {
     gradleVersion = '3.5'
 }
 
-version '2.5'
+version '2.6'

--- a/src/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
+++ b/src/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
@@ -76,7 +76,7 @@ public class AppCommandLineState extends JavaCommandLineState {
             String adminPort = configuration.getAdminPort();
             String tomcatVersion = configuration.getTomcatInfo().getVersion();
             String vmOptions = configuration.getVmOptions();
-            String envOptions = configuration.getEnvOptions();
+            Map<String, String> envOptions = configuration.getEnvOptions();
 
             Project project = this.configuration.getProject();
 
@@ -113,9 +113,9 @@ public class AppCommandLineState extends JavaCommandLineState {
             updateServerConf(tomcatVersion, module, confPath, contextPath, docBase, port, ajpPort, adminPort);
 
 
-            javaParams.setPassParentEnvs(false);
+            javaParams.setPassParentEnvs(configuration.getPassParentEnvironmentVariables());
             javaParams.getVMParametersList().addParametersString(vmOptions);
-            javaParams.setEnv(parseEnvVariables(envOptions));
+            javaParams.setEnv(envOptions);
             return javaParams;
 
         } catch (Exception e) {
@@ -123,21 +123,6 @@ public class AppCommandLineState extends JavaCommandLineState {
         }
 
 
-    }
-
-    private Map<String, String> parseEnvVariables(String variables) {
-        Map<String, String> map = new HashMap<>();
-        if (variables == null || variables.trim().equals("")) return map;
-        try {
-            String[] tokens = variables.split(" ");
-            for (String token : tokens) {
-                String[] subTokens = token.trim().split("=");
-                map.put(subTokens[0], subTokens[1]);
-            }
-            return map;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Nullable

--- a/src/com/poratu/idea/plugins/tomcat/conf/TomcatRunConfiguration.java
+++ b/src/com/poratu/idea/plugins/tomcat/conf/TomcatRunConfiguration.java
@@ -2,6 +2,7 @@ package com.poratu.idea.plugins.tomcat.conf;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.module.Module;
@@ -17,6 +18,9 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Author : zengkid
  * Date   : 2/16/2017
@@ -31,7 +35,8 @@ public class TomcatRunConfiguration extends RunConfigurationBase implements RunP
     private String ajpPort;
     private String adminPort;
     private String vmOptions;
-    private String envOptions;
+    private Map<String, String> envOptions;
+    private Boolean passParentEnvironmentVariables;
 
 
     protected TomcatRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory, String name) {
@@ -73,7 +78,11 @@ public class TomcatRunConfiguration extends RunConfigurationBase implements RunP
         this.ajpPort = JDOMExternalizerUtil.readField(element, "AJP_PORT");
         this.adminPort = JDOMExternalizerUtil.readField(element, "ADMIN_PORT");
         this.vmOptions = JDOMExternalizerUtil.readField(element, "VM_OPTIONS");
-        this.envOptions = JDOMExternalizerUtil.readField(element, "ENV_OPTIONS");
+        if(envOptions == null) {
+            envOptions = new HashMap<String, String>();
+        }
+        EnvironmentVariablesComponent.readExternal(element, envOptions);
+        this.passParentEnvironmentVariables = Boolean.valueOf(JDOMExternalizerUtil.readField(element, "PASS_PARENT_ENV_OPTIONS"));
     }
 
     @Override
@@ -88,7 +97,13 @@ public class TomcatRunConfiguration extends RunConfigurationBase implements RunP
         JDOMExternalizerUtil.writeField(element, "AJP_PORT", ajpPort);
         JDOMExternalizerUtil.writeField(element, "ADMIN_PORT", adminPort);
         JDOMExternalizerUtil.writeField(element, "VM_OPTIONS", vmOptions);
-        JDOMExternalizerUtil.writeField(element, "ENV_OPTIONS", envOptions);
+        if(envOptions != null && !envOptions.isEmpty()) {
+            EnvironmentVariablesComponent.writeExternal(element, envOptions);
+        }
+        if(passParentEnvironmentVariables == null) {
+            passParentEnvironmentVariables = Boolean.TRUE;
+        }
+        JDOMExternalizerUtil.writeField(element, "PASS_PARENT_ENV_OPTIONS", "" + passParentEnvironmentVariables);
     }
 
     public String getDocBase() {
@@ -147,10 +162,18 @@ public class TomcatRunConfiguration extends RunConfigurationBase implements RunP
         this.vmOptions = vmOptions;
     }
 
-    public String getEnvOptions() { return envOptions; }
+    public Map<String, String> getEnvOptions() { return envOptions; }
 
-    public void setEnvOptions(String envOptions) {
+    public void setEnvOptions(Map<String, String> envOptions) {
         this.envOptions = envOptions;
+    }
+
+    public Boolean getPassParentEnvironmentVariables() {
+        return passParentEnvironmentVariables;
+    }
+
+    public void setPassParentEnvironmentVariables(Boolean passParentEnvironmentVariables) {
+        this.passParentEnvironmentVariables = passParentEnvironmentVariables;
     }
 
     @NotNull

--- a/src/com/poratu/idea/plugins/tomcat/conf/TomcatSettingsEditor.java
+++ b/src/com/poratu/idea/plugins/tomcat/conf/TomcatSettingsEditor.java
@@ -27,6 +27,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.text.NumberFormat;
+import java.util.Map;
 
 /**
  * Author : zengkid
@@ -86,9 +87,14 @@ public class TomcatSettingsEditor extends SettingsEditor<TomcatRunConfiguration>
             runnerSetting.getVmOptons().setText(vmOptions);
         }
 
-        String envOptions = tomcatRunConfiguration.getEnvOptions();
-        if (envOptions != null && !"".equals(envOptions.trim())) {
-            runnerSetting.getEnvOptions().setText(envOptions);
+        Map<String, String> envOptions = tomcatRunConfiguration.getEnvOptions();
+        if (envOptions != null && !envOptions.isEmpty()) {
+            runnerSetting.getEnvOptions().setEnvs(envOptions);
+        }
+
+        Boolean passParentEnvs = tomcatRunConfiguration.getPassParentEnvironmentVariables();
+        if (passParentEnvs != null) {
+            runnerSetting.getEnvOptions().setPassParentEnvs(passParentEnvs);
         }
 
     }
@@ -106,7 +112,8 @@ public class TomcatSettingsEditor extends SettingsEditor<TomcatRunConfiguration>
         tomcatRunConfiguration.setAjpPort(runnerSetting.getAjpPort().getText());
         tomcatRunConfiguration.setAdminPort(runnerSetting.getAdminPort().getText());
         tomcatRunConfiguration.setVmOptions(runnerSetting.getVmOptons().getText());
-        tomcatRunConfiguration.setEnvOptions(runnerSetting.getEnvOptions().getText());
+        tomcatRunConfiguration.setEnvOptions(runnerSetting.getEnvOptions().getEnvs());
+        tomcatRunConfiguration.setPassParentEnvironmentVariables(runnerSetting.getEnvOptions().isPassParentEnvs());
     }
 
     @NotNull

--- a/src/com/poratu/idea/plugins/tomcat/setting/RunnerSetting.form
+++ b/src/com/poratu/idea/plugins/tomcat/setting/RunnerSetting.form
@@ -139,14 +139,14 @@
           <text value="Env options"/>
         </properties>
       </component>
-      <component id="43f5c" class="com.intellij.ui.RawCommandLineEditor" binding="envOptions">
+      <component id="43f5c" class="com.intellij.execution.configuration.EnvironmentVariablesComponent" binding="envOptions">
         <constraints>
           <grid row="14" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
           <forms/>
         </constraints>
         <properties>
-          <dialogCaption value="VM options"/>
           <text value=""/>
+          <toolTipText value="Warning: Experimental feature, use with extreme caution."/>
         </properties>
       </component>
       <component id="49ebe" class="javax.swing.JLabel">

--- a/src/com/poratu/idea/plugins/tomcat/setting/RunnerSetting.java
+++ b/src/com/poratu/idea/plugins/tomcat/setting/RunnerSetting.java
@@ -1,5 +1,6 @@
 package com.poratu.idea.plugins.tomcat.setting;
 
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.project.Project;
@@ -39,7 +40,7 @@ public class RunnerSetting {
 
     private JXButton configrationButton;
     private RawCommandLineEditor vmOptons;
-    private RawCommandLineEditor envOptions;
+    private EnvironmentVariablesComponent envOptions;
     private JFormattedTextField ajpPort;
     private JFormattedTextField adminPort;
     private Project project;
@@ -84,7 +85,7 @@ public class RunnerSetting {
         return vmOptons;
     }
 
-    public RawCommandLineEditor getEnvOptions() {
+    public EnvironmentVariablesComponent getEnvOptions() {
         return envOptions;
     }
 


### PR DESCRIPTION
This change uses the built-in Environment Variables component. Also takes the 'pass parent environment variables' setting from the same component.