### PR TITLE
Added support for tomcat installations with spaces in their paths

### DIFF
--- a/src/com/poratu/idea/plugins/tomcat/utils/PluginUtils.java
+++ b/src/com/poratu/idea/plugins/tomcat/utils/PluginUtils.java
@@ -32,7 +32,7 @@ public abstract class PluginUtils {
 
     public static TomcatInfo getTomcatInfo(String javaHome, String tomcatHome) {
 //        java -cp lib/catalina.jar org.apache.catalina.util.ServerInfo
-        String command = javaHome + "/bin/java -cp " + tomcatHome + "/lib/catalina.jar org.apache.catalina.util.ServerInfo";
+        String command = javaHome + "/bin/java -cp \"" + tomcatHome + "\"/lib/catalina.jar org.apache.catalina.util.ServerInfo";
         BufferedReader reader = null;
         final TomcatInfo tomcatInfo = new TomcatInfo();
         tomcatInfo.setPath(tomcatHome);


### PR DESCRIPTION
Tomcat installations with spaces was failing
See #13 #12 
The fix is simply to enclose the path in quotes (") when getting the installation info
Tested to work in Windows and Linux (don't have access to mac, but it should work too)