### PR TITLE
Fix the failed to launch problem

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
@@ -109,7 +109,8 @@ public class AppCommandLineState extends JavaCommandLineState {
             }
 
             String loggingConfig = "-Djava.util.logging.config.file=" + confPath.resolve("logging.properties");
-            javaParams.getVMParametersList().addAll(loggingConfig, PARAM_LOGGING_MANAGER, vmOptions);
+            javaParams.getVMParametersList().addAll(loggingConfig, PARAM_LOGGING_MANAGER);
+            javaParams.getVMParametersList().addParametersString(vmOptions);
             return javaParams;
 
         } catch (Exception e) {


### PR DESCRIPTION
Introduced in #67 , the reason is that `javaParams.getVMParametersList().addAll()` and `javaParams.getVMParametersList().addParametersString()` are different when handling the empty string. The former won't ignore any empty strings, so it introduced an empty string `""`, which will break the Smart Tomcat plugin.