### PR TITLE
fix: kill the progress gracefully when stopping Tomcat

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
@@ -4,6 +4,8 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.JavaCommandLineState;
 import com.intellij.execution.configurations.JavaParameters;
+import com.intellij.execution.process.KillableProcessHandler;
+import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.module.Module;
@@ -65,6 +67,15 @@ public class AppCommandLineState extends JavaCommandLineState {
         this.configuration = configuration;
     }
 
+    @Override
+    @NotNull
+    protected OSProcessHandler startProcess() throws ExecutionException {
+        OSProcessHandler progressHandler = super.startProcess();
+        if (progressHandler instanceof KillableProcessHandler) {
+            ((KillableProcessHandler) progressHandler).setShouldKillProcessSoftly(true);
+        }
+        return progressHandler;
+    }
 
     @Override
     protected JavaParameters createJavaParameters() {

--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/AppCommandLineState.java
@@ -1,5 +1,6 @@
 package com.poratu.idea.plugins.tomcat.conf;
 
+import com.intellij.debugger.settings.DebuggerSettings;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.JavaCommandLineState;
@@ -72,7 +73,8 @@ public class AppCommandLineState extends JavaCommandLineState {
     protected OSProcessHandler startProcess() throws ExecutionException {
         OSProcessHandler progressHandler = super.startProcess();
         if (progressHandler instanceof KillableProcessHandler) {
-            ((KillableProcessHandler) progressHandler).setShouldKillProcessSoftly(true);
+            boolean shouldKillSoftly = !DebuggerSettings.getInstance().KILL_PROCESS_IMMEDIATELY;
+            ((KillableProcessHandler) progressHandler).setShouldKillProcessSoftly(shouldKillSoftly);
         }
         return progressHandler;
     }


### PR DESCRIPTION
Kill the progress softly unless the `Kill the debug process immediately` option is checked.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/3297602/184494594-e8d3df3e-6a64-459e-966d-6db61ee38423.png">
