### PR TITLE
Fixed bug #114 - Guard against NPE if shutdown port or plain HTTP connector can't be found.

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/TomcatCommandLineState.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/TomcatCommandLineState.java
@@ -196,8 +196,12 @@ public class TomcatCommandLineState extends JavaCommandLineState {
             }
         }
 
-        portShutdown.setAttribute("port", String.valueOf(cfg.getAdminPort()));
-        portE.setAttribute("port", String.valueOf(cfg.getPort()));
+        if (portShutdown != null) {
+            portShutdown.setAttribute("port", String.valueOf(cfg.getAdminPort()));
+        }
+        if (portE != null) {
+            portE.setAttribute("port", String.valueOf(cfg.getPort()));
+        }
         Integer sslPort = cfg.getSslPort();
 
         if (sslPortE != null && sslPort != null) {


### PR DESCRIPTION
I've run into https://github.com/zengkid/SmartTomcat/issues/114 too as our Tomcat config disables the shutdown port and the non-https connector. Simple fix by checking the node aren't null before modifying them.