### PR TITLE
fix: Do not copy Tomcat configs file when <project>/.smarttomcat/<module>/conf folder is empty

### DIFF
--- a/src/main/java/com/poratu/idea/plugins/tomcat/conf/TomcatCommandLineState.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/conf/TomcatCommandLineState.java
@@ -120,7 +120,7 @@ public class TomcatCommandLineState extends JavaCommandLineState {
 
             //copy to project folder, and then user is able to update server.xml under the project.
             Path projectConfPath = Paths.get(project.getBasePath(), ".smarttomcat", module.getName(), "conf");
-            if (!projectConfPath.toFile().exists()) {
+            if (!projectConfPath.toFile().exists() || PluginUtils.isEmptyFolder(projectConfPath)) {
                 FileUtil.createDirectory(projectConfPath.toFile());
                 FileUtil.copyDir(tomcatInstallationPath.resolve("conf").toFile(), projectConfPath.toFile());
             }

--- a/src/main/java/com/poratu/idea/plugins/tomcat/utils/PluginUtils.java
+++ b/src/main/java/com/poratu/idea/plugins/tomcat/utils/PluginUtils.java
@@ -309,4 +309,22 @@ public final class PluginUtils {
 
         return ModuleUtilCore.findModuleForFile(virtualFile, project);
     }
+
+    /**
+     * Checks if the given folder is empty.
+     *
+     * @param path the path to the folder
+     * @return {@code true} if the folder exists and is empty, {@code false} otherwise
+     * @throws IOException if an I/O error occurs
+     */
+
+    public static boolean isEmptyFolder(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> entries = Files.list(path)) {
+                return !entries.findFirst().isPresent();
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
This pull request fixes an issue where the plugin does not check whether the config folder in the working project is empty before copying its contents to the Catalina base folder. If the folder exists but is empty, the plugin proceeds without copying the default Tomcat configuration files, which can lead to runtime errors such as "server.xml not found".

This update ensures that if the working project's config folder is empty, the plugin first populates it with the default Tomcat configuration before copying the files to the Catalina base folder. This prevents missing configuration errors during Tomcat startup.